### PR TITLE
1.4.0 update

### DIFF
--- a/plugin_settings.py
+++ b/plugin_settings.py
@@ -7,10 +7,12 @@ from plugins.doaj_transporter import events as plugin_events
 PLUGIN_NAME = 'DOAJ Transporter'
 DESCRIPTION = 'A plugin for exporting metadata to DOAJ via their API'
 AUTHOR = 'Mauro Sanchez'
-VERSION = '1.0'
+VERSION = '1.1'
 SHORT_NAME = 'doaj_transporter'
 DISPLAY_NAME = 'DOAJ Transporter'
 MANAGER_URL = 'doaj_index'
+JANEWAY_VERSION = '1.4.0'
+
 
 PLUGIN_PATH = os.path.dirname(os.path.realpath(__file__))
 JSON_SETTINGS_PATH = os.path.join(PLUGIN_PATH, "install/settings.json")

--- a/translation.py
+++ b/translation.py
@@ -1,0 +1,10 @@
+from modeltranslation.translator import register, TranslationOptions
+
+from submission import translation as sm_translation
+
+from plugins.doaj_transporter import models
+
+
+@register(models.Article)
+class NoTranslationOptions(TranslationOptions):
+    fields = ()


### PR DESCRIPTION
Fixes a compatibility issue with django-modeltranslations: Proxymodels need to be registered as well with the translator, providing an empty `fields` attribute