### PR TITLE
DOAJ transporter now uses FrozenAuthor records when sending data.

### DIFF
--- a/clients.py
+++ b/clients.py
@@ -286,7 +286,8 @@ class DOAJArticle_v1(BaseDOAJClient):
         doaj_article.year = int(article.date_published.year)
         doaj_article.month = int(article.date_published.month)
         doaj_article.author = [
-            cls.transform_author(a) for a in article.authors.all()]
+            cls.transform_author(a) for a in article.frozen_authors()
+        ]
         doaj_article.journal = cls.transform_journal(article)
         doaj_article.keywords = [
             kw.word

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -39,7 +39,7 @@ class TestDOAJArticleClient(TestCase):
         press = helpers.create_press()
         self.journal, _ = helpers.create_journals()
         self.journal.save()
-        call_command('load_default_settings', management_command=False)
+        call_command('load_default_settings')
         self.journal.publisher = "doaj"
         self.journal.code = "doaj"
         self.journal.save()
@@ -123,7 +123,7 @@ class TestDOAJArticleClient(TestCase):
         author.last_name = "Musketeer"
         author.institution = "OLH"
         author.save()
-        article.authors.add(author)
+        author.snapshot_self(article=article)
         article.owner = author
 
         issue = Issue.objects.create(
@@ -152,7 +152,6 @@ class TestDOAJArticleClient(TestCase):
         )
         article.galley_set.add(pdf_galley)
         article.save()
-        article.snapshot_authors(article)
         return article
 
     @override_settings(DOAJ_API_TOKEN="dummy_key")


### PR DESCRIPTION
Note:

The tests were borked _before_ this update and nothing about this change has fixed them other than avoiding the deprecation warning on `snapshot_authors`.