### PR TITLE
#14 Update clients.py to pass remote URL to DOAJ when it's available

### DIFF
--- a/clients.py
+++ b/clients.py
@@ -416,13 +416,13 @@ class DOAJArticle_v1(BaseDOAJClient):
             links.append(LinkStruct(
                 content_type="text/html",
                 type="fulltext",
-                url=article.url,
+                url={% if article.is_remote and article.remote_url %}{{ article.remote_url }}{% else %}{{ article.url }}{% endif %},
             ))
         if article.pdfs:
             links.append(LinkStruct(
                 content_type="application/pdf",
                 type="fulltext",
-                url=article.pdf_url,
+                url={% if article.is_remote and article.remote_url %}{{ article.remote_url }}{% else %}{{ article.pdf_url }}{% endif %},
             ))
 
         return links

--- a/clients.py
+++ b/clients.py
@@ -416,13 +416,13 @@ class DOAJArticle_v1(BaseDOAJClient):
             links.append(LinkStruct(
                 content_type="text/html",
                 type="fulltext",
-                url={% if article.is_remote and article.remote_url %}{{ article.remote_url }}{% else %}{{ article.url }}{% endif %},
+                url=article.remote_url if (article.is_remote and article.remote_url) else article.url,
             ))
         if article.pdfs:
             links.append(LinkStruct(
                 content_type="application/pdf",
                 type="fulltext",
-                url={% if article.is_remote and article.remote_url %}{{ article.remote_url }}{% else %}{{ article.pdf_url }}{% endif %},
+                url=article.remote_url if (article.is_remote and article.remote_url) else article.pdf_url,
             ))
 
         return links


### PR DESCRIPTION
In order to pass remote URLs to DOAJ when they are available, replaced reference to article.url with {% if article.is_remote and article.remote_url %}{{ article.remote_url }}{% else %}{{ article.url }}{% endif %} and since there seems to be no remote equivalent to article.pdf_url, replaced that reference with same.

Closes https://github.com/openlibhums/doaj_transporter/issues/14